### PR TITLE
feat: Set tunnel name to 'colab-connect'

### DIFF
--- a/colabconnect/colabconnect.py
+++ b/colabconnect/colabconnect.py
@@ -13,7 +13,7 @@ message = """
 
 
 def start_tunnel() -> None:
-    command = "./code tunnel --accept-server-license-terms --random-name"
+    command = "./code tunnel --accept-server-license-terms --name colab-connect"
     p = subprocess.Popen(
         command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )


### PR DESCRIPTION
Set tunnel name to a fixed name 'colab-connect', so you don't have to reopen the folder and files every times after reconnection, and you can simply refresh the page once the tunnel starts running again in a new colab VM to continue your work.